### PR TITLE
fix: do not use build cache

### DIFF
--- a/.github/workflows/docker_hub_latest_puglish.yml
+++ b/.github/workflows/docker_hub_latest_puglish.yml
@@ -20,14 +20,6 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
 
-        - name: Cache Docker layers
-          uses: actions/cache@v2
-          with:
-            path: /tmp/.buildx-cache
-            key: ${{ runner.os }}-buildx-${{ github.sha }}
-            restore-keys: |
-              ${{ runner.os }}-buildx-
-
         - name: Set up Docker Buildx
           id: buildx
           uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
 to use latest base image even if my source is not updated.