### PR TITLE
fix: use min-css-extract-pluigin 2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   },
   "devDependencies": {
     "serve": "^13.0.2"
+  },
+  "resolutions": {
+    "mini-css-extract-plugin": "2.4.5"
   }
 }


### PR DESCRIPTION
Build fails due to the following issue

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896